### PR TITLE
Update deps &c.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,3 @@
+PROJECT = calrissian
+
 include resources/make/common.mk

--- a/lfe.config
+++ b/lfe.config
@@ -1,7 +1,7 @@
 #(project
   (#(deps (#("lfex/lcfg" "master")))
    #(meta (
-     #(name logjam)
+     #(name calrissian)
      #(description "Monads for LFE")
      #(version "0.1.0")
      #(keywords ("LFE" "Lisp" "Library" "Monads"))

--- a/lfe.config
+++ b/lfe.config
@@ -1,0 +1,11 @@
+#(project
+  (#(deps (#("lfex/lcfg" "master")))
+   #(meta (
+     #(name logjam)
+     #(description "Monads for LFE")
+     #(version "0.1.0")
+     #(keywords ("LFE" "Lisp" "Library" "Monads"))
+     #(maintainers (
+       (#(name "Correl Roush") #(email "correl@gmail.com"))))
+     #(repos (
+       #(github "correl/calrissian")))))))

--- a/package.exs
+++ b/package.exs
@@ -1,7 +1,0 @@
-Expm.Package.new(
-  name: "calrissian",
-  description: "Monads for LFE",
-  version: "0.1.0",
-  keywords: ["LFE", "Lisp", "Library", "Monads"],
-  maintainers: [[name: "Correl Roush", email: "correl@gmail.com"]],
-  repositories: [[github: "correl/calrissian"]])

--- a/rebar.config
+++ b/rebar.config
@@ -7,5 +7,6 @@
 {deps, [
    {lfe, ".*", {git, "git://github.com/rvirding/lfe.git", "develop"}},
    {lutil, ".*", {git, "https://github.com/lfex/lutil.git", "master"}},
-   {ltest, ".*", {git, "git://github.com/lfex/ltest.git", "master"}}
+   {ltest, ".*", {git, "git://github.com/lfex/ltest.git", "master"}},
+   {lcfg, ".*", {git, "git://github.com/lfex/lcfg.git", "master"}}
   ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,16 +1,11 @@
-{erl_opts, [debug_info, {src_dirs, ["test/unit",
-                                    "test/integration",
-                                    "test/system"]}]}.
+{erl_opts, [debug_info, {src_dirs, ["test"]}]}.
 {lfe_first_files, []}.
 {deps_dir, ["deps"]}.
 {eunit_compile_opts, [
-   {src_dirs, ["test/unit",
-               "test/integration",
-               "test/system",
-               "src"]}
+   {src_dirs, ["test"]}
   ]}.
 {deps, [
    {lfe, ".*", {git, "git://github.com/rvirding/lfe.git", "develop"}},
-   {'lfe-utils', ".*", {git, "https://github.com/lfe/lfe-utils.git", "master"}},
-   {lfeunit, ".*", {git, "git://github.com/lfe/lfeunit.git", "master"}}
+   {lutil, ".*", {git, "https://github.com/lfex/lutil.git", "master"}},
+   {ltest, ".*", {git, "git://github.com/lfex/ltest.git", "master"}}
   ]}.

--- a/resources/make/common.mk
+++ b/resources/make/common.mk
@@ -110,7 +110,7 @@ check-all: get-deps clean-eunit compile-no-deps
 
 check: check-unit-with-deps
 
-check-travis: $(LFETOOL) check
+check-travis: $(BIN_DIR)/lfetool check
 
 push-all:
 	@echo "Pusing code to github ..."

--- a/resources/make/common.mk
+++ b/resources/make/common.mk
@@ -28,6 +28,9 @@ endif
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 
+$(BIN_DIR)/lfetool: $(BIN_DIR)
+	@make get-lfetool
+
 get-lfetool: $(BIN_DIR)
 	curl -L -o ./lfetool https://raw.github.com/lfe/lfetool/dev-v1/lfetool && \
 	chmod 755 ./lfetool && \

--- a/resources/make/common.mk
+++ b/resources/make/common.mk
@@ -1,98 +1,112 @@
-PROJECT = calrissian
+ifeq ($(shell which erl),)
+$(error Can't find Erlang executable 'erl')
+exit 1
+endif
+
 LIB = $(PROJECT)
 DEPS = ./deps
 BIN_DIR = ./bin
-EXPM = $(BIN_DIR)/expm
-
 SOURCE_DIR = ./src
 OUT_DIR = ./ebin
 TEST_DIR = ./test
 TEST_OUT_DIR = ./.eunit
 SCRIPT_PATH=$(DEPS)/lfe/bin:.:./bin:"$(PATH)":/usr/local/bin
-ERL_LIBS=$(shell pwd):$(shell $(LFETOOL) info erllibs)
-EMPTY =
-ifeq ($(shell which lfetool),$EMPTY)
-	LFETOOL=$(BIN_DIR)/lfetool
+ifeq ($(shell which lfetool),)
+LFETOOL=$(BIN_DIR)/lfetool
 else
-	LFETOOL=lfetool
+LFETOOL=lfetool
 endif
+ERL_LIBS=.:..:$(shell pwd):$(shell $(LFETOOL) info erllibs)
 OS := $(shell uname -s)
 ifeq ($(OS),Linux)
-        HOST=$(HOSTNAME)
+	HOST=$(HOSTNAME)
 endif
 ifeq ($(OS),Darwin)
-        HOST = $(shell scutil --get ComputerName)
+	HOST = $(shell scutil --get ComputerName)
 endif
 
 $(BIN_DIR):
 	mkdir -p $(BIN_DIR)
 
-$(LFETOOL): $(BIN_DIR)
-	@[ -f $(LFETOOL) ] || \
-	curl -L -o ./lfetool https://raw.github.com/lfe/lfetool/master/lfetool && \
+get-lfetool: $(BIN_DIR)
+	curl -L -o ./lfetool https://raw.github.com/lfe/lfetool/dev-v1/lfetool && \
 	chmod 755 ./lfetool && \
 	mv ./lfetool $(BIN_DIR)
 
 get-version:
-	@PATH=$(SCRIPT_PATH) lfetool info version
-
-$(EXPM): $(BIN_DIR)
-	@[ -f $(EXPM) ] || \
-	PATH=$(SCRIPT_PATH) lfetool install expm $(BIN_DIR)
+	@PATH=$(SCRIPT_PATH) $(LFETOOL) info version
+	@echo "Erlang/OTP, LFE, & library versions:"
+	@ERL_LIBS=$(ERL_LIBS) PATH=$(SCRIPT_PATH) erl \
+	-eval "lfe_io:format(\"~p~n\",['$(PROJECT)-util':'get-versions'()])." \
+	-noshell -s erlang halt
 
 get-deps:
 	@echo "Getting dependencies ..."
-	@which rebar.cmd >/dev/null 2>&1 && rebar.cmd get-deps || rebar get-deps
-	@PATH=$(SCRIPT_PATH) lfetool update deps
+	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) $(LFETOOL) download deps
 
 clean-ebin:
 	@echo "Cleaning ebin dir ..."
 	@rm -f $(OUT_DIR)/*.beam
 
 clean-eunit:
-	@PATH=$(SCRIPT_PATH) lfetool tests clean
+	-@PATH=$(SCRIPT_PATH) $(LFETOOL) tests clean
 
 compile: get-deps clean-ebin
 	@echo "Compiling project code and dependencies ..."
-	@which rebar.cmd >/dev/null 2>&1 && rebar.cmd compile || rebar compile
+	@which rebar.cmd >/dev/null 2>&1 && \
+	PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) rebar.cmd compile || \
+	PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) rebar compile
 
 compile-no-deps: clean-ebin
 	@echo "Compiling only project code ..."
-	@which rebar.cmd >/dev/null 2>&1 && rebar.cmd compile skip_deps=true || rebar compile skip_deps=true
+	@which rebar.cmd >/dev/null 2>&1 && \
+	PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) \
+	rebar.cmd compile skip_deps=true || \
+	PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) rebar compile skip_deps=true
 
-compile-tests:
-	@PATH=$(SCRIPT_PATH) lfetool tests build
+compile-tests: clean-eunit
+	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) $(LFETOOL) tests build
+
+repl: compile
+	@which clear >/dev/null 2>&1 && clear || printf "\033c"
+	@echo "Starting an LFE REPL ..."
+	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) $(LFETOOL) repl lfe +pc unicode
+
+repl-no-deps: compile-no-deps
+	@which clear >/dev/null 2>&1 && clear || printf "\033c"
+	@echo "Starting an LFE REPL ..."
+	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) $(LFETOOL) repl lfe +pc unicode
 
 shell: compile
 	@which clear >/dev/null 2>&1 && clear || printf "\033c"
-	@echo "Starting shell ..."
-	@PATH=$(SCRIPT_PATH) lfetool repl
+	@echo "Starting an Erlang shell ..."
+	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) erl + pc unicode
 
 shell-no-deps: compile-no-deps
 	@which clear >/dev/null 2>&1 && clear || printf "\033c"
-	@echo "Starting shell ..."
-	@PATH=$(SCRIPT_PATH) lfetool repl
+	@echo "Starting an Erlang shell ..."
+	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) erl + pc unicode
 
 clean: clean-ebin clean-eunit
 	@which rebar.cmd >/dev/null 2>&1 && rebar.cmd clean || rebar clean
 
 check-unit-only:
-	@PATH=$(SCRIPT_PATH) lfetool tests unit
+	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) $(LFETOOL) tests unit
 
 check-integration-only:
-	@PATH=$(SCRIPT_PATH) lfetool tests integration
+	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) $(LFETOOL) tests integration
 
 check-system-only:
-	@PATH=$(SCRIPT_PATH) lfetool tests system
+	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) $(LFETOOL) tests system
 
 check-unit-with-deps: get-deps compile compile-tests check-unit-only
-check-unit: compile-no-deps check-unit-only
-check-integration: compile check-integration-only
-check-system: compile check-system-only
-check-all-with-deps: compile check-unit-only check-integration-only \
-	check-system-only
-check-all: get-deps compile-no-deps
-	@PATH=$(SCRIPT_PATH) lfetool tests all
+check-unit: clean-eunit compile-no-deps check-unit-only
+check-integration: clean-eunit compile check-integration-only
+check-system: clean-eunit compile check-system-only
+check-all-with-deps: clean-eunit compile check-unit-only \
+	check-integration-only check-system-only clean-eunit
+check-all: get-deps clean-eunit compile-no-deps
+	@PATH=$(SCRIPT_PATH) ERL_LIBS=$(ERL_LIBS) $(LFETOOL) tests all
 
 check: check-unit-with-deps
 
@@ -106,16 +120,6 @@ push-all:
 	git push upstream --tags
 
 install: compile
-	@echo "Installing calrissian ..."
+	@echo "Installing lumberjack ..."
 	@PATH=$(SCRIPT_PATH) lfetool install lfe
 
-upload: $(EXPM) get-version
-	@echo "Preparing to upload calrissian ..."
-	@echo
-	@echo "Package file:"
-	@echo
-	@cat package.exs
-	@echo
-	@echo "Continue with upload? "
-	@read
-	$(EXPM) publish

--- a/resources/make/common.mk
+++ b/resources/make/common.mk
@@ -114,15 +114,3 @@ check-all: get-deps clean-eunit compile-no-deps
 check: check-unit-with-deps
 
 check-travis: $(BIN_DIR)/lfetool check
-
-push-all:
-	@echo "Pusing code to github ..."
-	git push --all
-	git push upstream --all
-	git push --tags
-	git push upstream --tags
-
-install: compile
-	@echo "Installing lumberjack ..."
-	@PATH=$(SCRIPT_PATH) lfetool install lfe
-

--- a/src/calrissian-util.lfe
+++ b/src/calrissian-util.lfe
@@ -1,8 +1,17 @@
 (defmodule calrissian-util
-  (export (module-info 1)
+  (export (get-version 0)
+          (get-versions 0)
+          (module-info 1)
           (module-info 2)
           (implements? 2)
           (exports? 2)))
+
+(defun get-version ()
+  (lutil:get-app-version 'calrissian))
+
+(defun get-versions ()
+  (++ (lutil:get-versions)
+      `(#(calrissian ,(get-version)))))
 
 (defun module-info
   (((tuple module _args))

--- a/test/unit-calrissian-error-monad-tests.lfe
+++ b/test/unit-calrissian-error-monad-tests.lfe
@@ -1,13 +1,10 @@
 (defmodule unit-calrissian-error-monad-tests
-  (export all)
-  (import
-    (from lfeunit-util
-      (check-failed-assert 2)
-      (check-wrong-assert-exception 2))))
+  (behaviour ltest-unit)
+  (export all))
 
-(include-lib "deps/lfeunit/include/lfeunit-macros.lfe")
-(include-lib "include/monads.lfe")
-(include-lib "include/monad-tests.lfe")
+(include-lib "ltest/include/ltest-macros.lfe")
+(include-lib "calrissian/include/monads.lfe")
+(include-lib "calrissian/include/monad-tests.lfe")
 
 (test-monad (monad 'error))
 

--- a/test/unit-calrissian-identity-monad-tests.lfe
+++ b/test/unit-calrissian-identity-monad-tests.lfe
@@ -1,13 +1,10 @@
 (defmodule unit-calrissian-identity-monad-tests
-  (export all)
-  (import
-    (from lfeunit-util
-      (check-failed-assert 2)
-      (check-wrong-assert-exception 2))))
+  (behaviour ltest-unit)
+  (export all))
 
-(include-lib "deps/lfeunit/include/lfeunit-macros.lfe")
-(include-lib "include/monads.lfe")
-(include-lib "include/monad-tests.lfe")
+(include-lib "ltest/include/ltest-macros.lfe")
+(include-lib "calrissian/include/monads.lfe")
+(include-lib "calrissian/include/monad-tests.lfe")
 
 (test-monad (monad 'identity))
 

--- a/test/unit-calrissian-maybe-monad-tests.lfe
+++ b/test/unit-calrissian-maybe-monad-tests.lfe
@@ -1,13 +1,10 @@
 (defmodule unit-calrissian-maybe-monad-tests
-  (export all)
-  (import
-    (from lfeunit-util
-      (check-failed-assert 2)
-      (check-wrong-assert-exception 2))))
+  (behaviour ltest-unit)
+  (export all))
 
-(include-lib "deps/lfeunit/include/lfeunit-macros.lfe")
-(include-lib "include/monads.lfe")
-(include-lib "include/monad-tests.lfe")
+(include-lib "ltest/include/ltest-macros.lfe")
+(include-lib "calrissian/include/monads.lfe")
+(include-lib "calrissian/include/monad-tests.lfe")
 
 (test-monad (monad 'maybe))
 

--- a/test/unit-calrissian-state-transformer-tests.lfe
+++ b/test/unit-calrissian-state-transformer-tests.lfe
@@ -1,13 +1,10 @@
 (defmodule unit-calrissian-state-transformer-tests
-  (export all)
-  (import
-    (from lfeunit-util
-      (check-failed-assert 2)
-      (check-wrong-assert-exception 2))))
+  (behaviour ltest-unit)
+  (export all))
 
-(include-lib "deps/lfeunit/include/lfeunit-macros.lfe")
-(include-lib "include/monads.lfe")
-(include-lib "include/monad-tests.lfe")
+(include-lib "ltest/include/ltest-macros.lfe")
+(include-lib "calrissian/include/monads.lfe")
+(include-lib "calrissian/include/monad-tests.lfe")
 
 (test-monad (transformer 'state 'identity))
 


### PR DESCRIPTION
This change set brings calrissian fully up-to-date with the latest LFE projects. All  unit tests still pass.

In addition to updating the deps, this branch does the following:
- updates the Makefile and make include to use the latest fixes in LFE projects
- updates the unit tests to use the successor to the old lfe-unit (ltest)
- removes EXPM (no longer supported or even extant in the Elixir community)
- replaces EXPM metadata file with lfe.config (a new addition used by the latest LFE projects)
- added the standard version info functions in the util module
